### PR TITLE
Remove extra `.default`

### DIFF
--- a/src/main/scala/com/github/fulrich/testcharged/generators/numerics/NumericGenerator.scala
+++ b/src/main/scala/com/github/fulrich/testcharged/generators/numerics/NumericGenerator.scala
@@ -24,6 +24,6 @@ abstract class NumericGenerator[T : Numeric : Choose] extends SizeApi[SignGenera
 object NumericGenerator {
   implicit def numericGeneratorDefaultCaller[T : Numeric : Choose]: DefaultCaller[T, NumericGenerator[T]] =
     new DefaultCaller[T, NumericGenerator[T]] {
-      override def apply(callee: NumericGenerator[T]): Gen[T] = callee.default.default
+      override def apply(callee: NumericGenerator[T]): Gen[T] = callee.default
     }
 }

--- a/src/test/scala/com/github/fulrich/testcharged/generators/GenerateDslUTest.scala
+++ b/src/test/scala/com/github/fulrich/testcharged/generators/GenerateDslUTest.scala
@@ -44,8 +44,6 @@ class GenerateDslUTest extends FunSuite with Matchers with GeneratorDrivenProper
   test("When accessing NumericGenerator value can omit the chained default calls") {
     val generatedNumeric = Generate.int.value
 
-    Generate.int.default.default.value
-
     generatedNumeric should be >= Math.negateExact(IntGenerators.DefaultMaximum)
     generatedNumeric should be <= IntGenerators.DefaultMaximum
   }


### PR DESCRIPTION
The implicit conversion should run if something isn't of type `Gen[T]` meaning that, if `default` doesn't return that type, the conversion will run again on the result of `default` until it does.