### PR TITLE
Fix: Removing weighted distribution from Numeric Generators

### DIFF
--- a/src/main/scala/com/github/fulrich/testcharged/generators/numerics/SignGenerator.scala
+++ b/src/main/scala/com/github/fulrich/testcharged/generators/numerics/SignGenerator.scala
@@ -6,9 +6,9 @@ import org.scalacheck.Gen.Choose
 
 
 case class SignGenerator[T : Choose](range: T)(implicit numeric: Numeric[T]) {
-  lazy val positive: Gen[T] = Gen.chooseNum[T](numeric.zero, range)
-  lazy val negative: Gen[T] = Gen.chooseNum[T](numeric.negate(range), numeric.zero)
-  lazy val default: Gen[T] = Gen.chooseNum[T](numeric.negate(range), range)
+  lazy val positive: Gen[T] = Gen.choose[T](numeric.zero, range)
+  lazy val negative: Gen[T] = Gen.choose[T](numeric.negate(range), numeric.zero)
+  lazy val default: Gen[T] = Gen.choose[T](numeric.negate(range), range)
 }
 
 object SignGenerator {

--- a/src/test/scala/com/github/fulrich/testcharged/generators/numerics/NumericGeneratorDistributionUTest.scala
+++ b/src/test/scala/com/github/fulrich/testcharged/generators/numerics/NumericGeneratorDistributionUTest.scala
@@ -1,0 +1,41 @@
+package com.github.fulrich.testcharged.generators.numerics
+
+import org.scalacheck.Gen
+import org.scalacheck.Gen.Choose
+import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+
+
+class NumericGeneratorDistributionUTest extends FunSuite with Matchers with GeneratorDrivenPropertyChecks {
+
+  test("The double generator does not weight extremities") {
+    ensureExtremitiesNotWeighted(DoubleGenerators)
+  }
+
+  test("The integer generator does not weight extremities") {
+    ensureExtremitiesNotWeighted(IntGenerators)
+  }
+
+  test("The long generator does not weight extremities") {
+    ensureExtremitiesNotWeighted(LongGenerators)
+  }
+
+  test("The float generator does not weight extremities") {
+    ensureExtremitiesNotWeighted(FloatGenerators)
+  }
+
+  test("The short generator does not weight extremities") {
+    ensureExtremitiesNotWeighted(ShortGenerators)
+  }
+
+  def ensureExtremitiesNotWeighted[A : Choose](generator: NumericGenerator[A])(implicit numeric: Numeric[A]): Unit = {
+    val sizeOfList: Int = 100
+    val fivePercent: Int = (sizeOfList * 0.05).toInt
+    val listGenerator: Gen[Seq[A]] = Gen.listOfN(sizeOfList, generator.default.default)
+
+    forAll(listGenerator) { generatedNumerics =>
+      generatedNumerics.count(_ == generator.DefaultMaximum) should be < fivePercent
+      generatedNumerics.count(_ == numeric.negate(generator.DefaultMaximum)) should be < fivePercent
+    }
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/fulrich/test-charged/issues/6

As reported in the issue above the numeric generators were using `chooseNum` which caused extremities and 0/1 to be weighted stronger. This is very useful for targeted testing but TestCharged is more focused on data generation at a larger scale.

This PR creates a test that checks that we don't have over 5% of our generated values being an extremity. It then updates our `NumericGenerators` to use `choose` instead of `chooseNum`