### PR TITLE
Updating to build with Scala 2.13.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 language: scala
 
 scala:
-  - 2.12.7
+  - 2.13.0
+  - 2.12.8
   - 2.11.12
 
 jdk:
@@ -33,7 +34,7 @@ after_success:
 stages:
   - name: test
   - name: release
-    if: ((branch = master AND type = push) OR (tag IS present)) AND NOT fork
+    if: tag IS present AND NOT fork
 
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # TestCharged
 [![Travis (.org)](https://img.shields.io/travis/fulrich/test-charged.svg?style=flat-square)](https://travis-ci.org/fulrich/test-charged)
 [![Codecov](https://img.shields.io/codecov/c/github/fulrich/test-charged.svg?style=flat-square)](https://codecov.io/gh/fulrich/test-charged)
-[![Scala Versions](https://img.shields.io/badge/scala-2.11%20%7C%202.12-blue.svg?style=flat-square)](https://github.com/fulrich/TestCharged/blob/455d73f549c5edd0d71d2d13748cd8c458483d20/build.sbt#L3)
+[![Scala Versions](https://img.shields.io/badge/scala-2.11%20%7C%202.12%20%7C%202.13-blue.svg?style=flat-square)](https://github.com/fulrich/TestCharged/blob/455d73f549c5edd0d71d2d13748cd8c458483d20/build.sbt#L3)
 
-[![Maven Central](https://img.shields.io/maven-central/v/com.github.fulrich/test-charged_2.12.svg?style=flat-square)](https://search.maven.org/artifact/com.github.fulrich/test-charged_2.12/0.1.5/jar)
-[![Sonatype Nexus (Snapshots)](https://img.shields.io/nexus/s/https/oss.sonatype.org/com.github.fulrich/test-charged_2.12.svg?style=flat-square)](https://oss.sonatype.org/content/repositories/snapshots/com/github/fulrich/test-charged_2.12/)
+[![Maven Central](https://img.shields.io/nexus/r/https/oss.sonatype.org/com.github.fulrich/test-charged_2.11.svg?label=latest%202.11&style=flat-square)](https://repo1.maven.org/maven2/com/github/fulrich/test-charged_2.11/)
+[![Maven Central](https://img.shields.io/nexus/r/https/oss.sonatype.org/com.github.fulrich/test-charged_2.12.svg?label=latest%202.12&style=flat-square)](https://repo1.maven.org/maven2/com/github/fulrich/test-charged_2.12/)
+[![Maven Central](https://img.shields.io/nexus/r/https/oss.sonatype.org/com.github.fulrich/test-charged_2.13.svg?label=latest%202.13&style=flat-square)](https://repo1.maven.org/maven2/com/github/fulrich/test-charged_2.13/)
 
 A small library with helpers for generating test data through a simple DSL.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,9 @@
-name := "Test Charged"
-crossScalaVersions := Seq("2.11.12", "2.12.8")
-
 inThisBuild(List(
+  name := "Test Charged",
   organization := "com.github.fulrich",
   homepage := Some(url("https://github.com/fulrich/testcharged")),
   licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+  crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
   developers := List(
     Developer(
       "fulrich",
@@ -16,13 +15,13 @@ inThisBuild(List(
 ))
 
 // Dependencies
-val ScalacticVersion = "3.0.5"
+val ScalacticVersion = "3.0.8"
 val ScalaCheckVersion = "1.14.0"
 
 libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % ScalaCheckVersion,
   "org.scalactic" %% "scalactic" % ScalacticVersion,
-  "org.scalatest" %% "scalatest" % ScalacticVersion % "test",
+  "org.scalatest" %% "scalatest" % ScalacticVersion % Test,
 )
 
 // Documentation

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.4
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,8 @@
 // Code Coverage
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 
 // Deployment
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.2.6")
 
 // Documentation
-addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.7.24")
+addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.9.1")


### PR DESCRIPTION
This PR updates all libraries to 2.13 compatible libraries. It also sets up TestCharged to build and release on Scala 2.13. 

Also included is an update to the Travis file to turn off SNAPSHOT releases. They were slowing down builds and I don't believe they are heavily used. This decision can be reexamined later but I am happy with it for now.