### PR TITLE
Improve CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,15 @@ jobs:
         shell: bash
         run: sbt ++"$SCALA_VERSION" test
 
+  build:
+    name: Build
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: CI Passed
+        run: echo CI Passed | tee -a "$GITHUB_STEP_SUMMARY"
+
   coverage:
     name: Code Coverage
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - "project/*"
       - "*.sbt"
       - ".github/workflows/ci.yml"
+    types:
+      - "opened"
+      - "reopened"
+      - "synchronize"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/scala-steward.yml
+++ b/.github/workflows/scala-steward.yml
@@ -12,6 +12,7 @@ jobs:
   scala-steward:
     runs-on: ubuntu-latest
     name: Scala Steward
+    if: github.event_name == 'workflow_dispatch' || vars.RUN_SCALA_STEWARD
     steps:
       - name: Scala Steward
         uses: scala-steward-org/scala-steward-action@v2

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -69,9 +69,6 @@ on:
       - "opened"
       - "reopened"
       - "synchronize"
-  issue_comment:
-    types:
-      - "created"
 
 jobs:
   spelling:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - name: check-spelling
         id: spelling
-        uses: check-spelling/check-spelling@prerelease
+        uses: check-spelling/check-spelling@v0.0.24
         with:
           suppress_push_for_open_pull_request: ${{ github.actor != 'dependabot[bot]' && 1 }}
           checkout: true


### PR DESCRIPTION
* [ci(check-spelling): Remove comment handler](https://github.com/GarnerCorp/test-charged/commit/4702e6b98383d09fa80b87c5c6c3d5fe3ec8ca32) -- the workflow doesn't have the job to respond to comments
* [ci(check-spelling): Pin current latest release](https://github.com/GarnerCorp/test-charged/commit/009f483bc6028e250cdce2bc908800a5f82af64e) -- there will be a v0.0.25 very soon, but in the interim, this is a public repository so it should be running the current release (we'll probably switch to SHA pinning unless check-spelling gets immutable versions from GitHub...)
* [ci(ci): Run checks for additional cases](https://github.com/GarnerCorp/test-charged/commit/fc3169a87165da17afd8b11ffa73f176b7818533) -- when scala-steward makes a PR, it doesn't trigger CI, so in order to trigger CI, someone needs to close and reopen the PR -- with this, the CI will run
* [ci(scala-steward): Only run on schedule if enabled](https://github.com/GarnerCorp/test-charged/pull/22/commits/4db3e6c478a7769819d37e1b6ddfb98621e342dd) -- this allows forks to opt-in to scala-steward (it's off by default since most forks aren't expected to want to run it)
* [ci(ci): Add job for success](https://github.com/GarnerCorp/test-charged/pull/22/commits/d005d916c3ee6be6e77ad3bd8445cbc4e4a3a858) -- this enables using a ruleset to require passing CI