### PR TITLE
Brickie dependency updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Cache Java/SBT
         if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.sbt/
@@ -88,7 +88,7 @@ jobs:
 
       - name: Cache Java/SBT
         if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.sbt/
@@ -147,7 +147,7 @@ jobs:
 
       - name: Cache Java/SBT
         if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: |
             ~/.sbt/

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,3 @@
-version=3.11.0
+version=3.11.4
 runner.dialect = "scala213"
 trailingCommas = preserve

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.12.13
+sbt.version = 1.12.14

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
 // Versions intentionally spaced to avoid merge conflicts from GitHub auto-bump bots
 
 // Formatting
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.2")
 
 // Code Coverage
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.4.4")


### PR DESCRIPTION
<!-- brickie-run: 20260720-0qwvF9 -->
<!-- brickie-input-hash: cac00271320f71dad6b62a5f9fe9df41dd93a454195b603803dcd70e7f146b8e -->

Aggregates the reviewed dependency-bot updates from these frozen source heads:

- Closes #126 — Update sbt, scripted-plugin to 1.12.14 (`c977786f8838da169b986ea912315fb591debc50`)
- Closes #127 — Update sbt-scalafmt to 2.6.2 (`ec4c92d0635ca26ea553d28a69eb60b8d9e5dca2`)
- Closes #128 — Update scalafmt-core to 3.11.4 (`61162032f13a648e2dfe6f6c07e1a2d5e7cd080f`)
- Closes #122 — Bump actions/cache from 5 to 6 (`725acecf4ff0579f9544aade0787a6c6e64e7283`)

The major-version source in this input set was explicitly approved as `UPGRADE_MAJOR` for its exact head SHA.

Local validation:

- source and prepared stable patch IDs match
- Ruby YAML and yq parsing passed; exactly three actions/cache@v6 steps and no v1-v5 references
- sbt +test passed on Scala 2.12, 2.13, and 3 (47 tests each)
- 61 Scala sources passed scalafmtCheckAll; git diff --check passed

This run does not authorize merge or auto-merge. Normal review, required checks, and a separate merge decision still apply.
